### PR TITLE
chore: add smart release detection and improve workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,13 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    outputs:
+      new-release-published: ${{ steps.semantic.outputs.new-release-published }}
+      new-release-version: ${{ steps.semantic.outputs.new-release-version }}
     # Only run when PR is merged or workflow is manually triggered
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.merged == true
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -70,11 +75,25 @@ jobs:
           npx semantic-release --dry-run
 
       - name: Run semantic-release
+        id: semantic
         if: github.event.inputs.dry-run != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx semantic-release
+          npx semantic-release > semantic-output.log 2>&1 || true
+          cat semantic-output.log
+
+          # Check if release was published
+          if grep -q "Published release" semantic-output.log || grep -q "Release published" semantic-output.log; then
+            echo "new-release-published=true" >> $GITHUB_OUTPUT
+            # Extract version from package.json after semantic-release
+            NEW_VERSION=$(jq -r '.version' package.json)
+            echo "new-release-version=$NEW_VERSION" >> $GITHUB_OUTPUT
+            echo "Release published: v$NEW_VERSION"
+          else
+            echo "new-release-published=false" >> $GITHUB_OUTPUT
+            echo "No release published"
+          fi
 
       - name: Get released version
         id: version
@@ -84,10 +103,10 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Released version: $VERSION"
 
-      - name: Summary
-        if: github.event.inputs.dry-run != 'true' && steps.version.outputs.VERSION
+      - name: Summary - Release Created
+        if: github.event.inputs.dry-run != 'true' && steps.semantic.outputs.new-release-published == 'true'
         run: |
-          VERSION="${{ steps.version.outputs.VERSION }}"
+          VERSION="${{ steps.semantic.outputs.new-release-version }}"
           echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Version**: v$VERSION" >> $GITHUB_STEP_SUMMARY
@@ -103,12 +122,24 @@ jobs:
           echo "### Next Steps" >> $GITHUB_STEP_SUMMARY
           echo "- ⏳ NPM Publish workflow will trigger automatically" >> $GITHUB_STEP_SUMMARY
 
+      - name: Summary - No Release
+        if: github.event.inputs.dry-run != 'true' && steps.semantic.outputs.new-release-published != 'true'
+        run: |
+          echo "## No Release Created" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "No new version was released because:" >> $GITHUB_STEP_SUMMARY
+          echo "- No commits with release-triggering types (feat, fix, perf, revert, breaking changes)" >> $GITHUB_STEP_SUMMARY
+          echo "- Or all commits since last release are non-release types (chore, docs, style, refactor, test)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Current version" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version**: $(jq -r '.version' package.json)" >> $GITHUB_STEP_SUMMARY
+
   # Trigger NPM publish workflow after release is complete
   publish:
     name: Trigger NPM Publish
     needs: release
     runs-on: ubuntu-latest
-    if: github.event.inputs.dry-run != 'true'
+    if: github.event.inputs.dry-run != 'true' && needs.release.outputs.new-release-published == 'true'
     steps:
       - name: Trigger use-shared-publish workflow
         uses: actions/github-script@v7

--- a/.github/workflows/use-shared-publish.yml
+++ b/.github/workflows/use-shared-publish.yml
@@ -1,16 +1,10 @@
 name: Build and Publish
 
 on:
-  pull_request:
-    types:
-    - closed
-    branches:
-    - master
   workflow_dispatch:
 
 jobs:
   build-and-publish:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     uses: newrelic/video-core-js/.github/workflows/npm-publish.yml@stable
     with:
       s3-path: 'media-agents/browser/html5'


### PR DESCRIPTION
- Capture semantic-release outputs for new-release-published detection
- Add accurate summary messages based on release status
- Update publish job to only trigger when release is created
- Simplify use-shared-publish.yml to workflow_dispatch only