### PR TITLE
chore: add explicit workflow permissions (CodeQL NR-560090)

### DIFF
--- a/.github/workflows/use-shared-publish.yml
+++ b/.github/workflows/use-shared-publish.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     uses: newrelic/video-core-js/.github/workflows/npm-publish.yml@stable


### PR DESCRIPTION
Adds `permissions: contents: read` to `use-shared-publish.yml` to satisfy CodeQL `actions/missing-workflow-permissions`. AWS S3/npm publish steps use repository secrets not GITHUB_TOKEN so there is no functional impact. Resolves NR-560090.